### PR TITLE
Fixed Python 3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,7 @@ Requirements
 ============
 
 - Pingdom account
-- simplejson (Python 2.5 and earlier)
-- requests
+- requests (0.10.8 or newer)
 
 =============
 Documentation

--- a/pingdom/connection.py
+++ b/pingdom/connection.py
@@ -6,11 +6,6 @@
 """
 
 import logging
-
-try:
-    import json
-except:
-    import simplejson as json
 import requests
 from requests.auth import HTTPBasicAuth
 
@@ -92,7 +87,7 @@ class PingdomResponse(object):
         """Representation of a Pingdom API HTTP response."""
 
         self.headers = response.headers
-        self.content = json.loads(response.content)
+        self.content = response.json()
 
         if response.status_code >= 300:
             raise PingdomError(response)

--- a/pingdom/exception.py
+++ b/pingdom/exception.py
@@ -4,7 +4,10 @@
     pingdom.exception
 
 """
-from urllib2 import HTTPError
+try:
+    from urllib2 import HTTPError
+except:
+    from urllib.error import HTTPError
 
 try:
     import json

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 
+import sys
 from setuptools import setup
+
+extra = {}
+if sys.version_info >= (3,):
+    extra['use_2to3'] = True
 
 setup(name='pingdom',
       version="0.2.0",
@@ -7,7 +12,7 @@ setup(name='pingdom',
       long_description="""3rd-party Python interface to Pingdom's REST API.""",
       author='Mike Babineau',
       author_email='michael.babineau@gmail.com',
-      install_requires=[ 'requests>=0.10.8', 'simplejson'],
+      install_requires=[ 'requests>=0.10.8' ],
       url='https://github.com/mbabineau/pingdom-python',
       packages=['pingdom'],
       license='Apache v2.0',
@@ -18,4 +23,5 @@ setup(name='pingdom',
                    'License :: OSI Approved :: Apache Software License',
                    'Operating System :: OS Independent',
                    'Topic :: System :: Monitoring', ],
+      **extra
       )


### PR DESCRIPTION
### Motivation

Running pingdom-python on Python 3 results in syntax errors at both install-time and run-time. After some deeper investigation, I found two problems.
##### 1. Invalid syntax

In Python 3, the following try/except block syntax is no longer valid.

``` python
except PingdomError, e:
```

This must be changed to:

``` python
except PingdomError as e:
```

This can be automatically done at install-time using the `use_2to3` switch in setuptools.
##### 2. Broken JSON parsing

The JSON parsing fails on Python 3.

``` python
class PingdomResponse(object):
    def __init__(self, response):
        """Representation of a Pingdom API HTTP response."""

        self.headers = response.headers
        self.content = json.loads(response.content)
```

`response.content` returns a `bytes` object in Python 3. It returns a `str` object in Python 2. `json.loads` accepts a `str` object as an argument (as well as `unicode` on Python 2). I figured we could just use `response.json()` and let the `requests` package handle the JSON parsing (as well as encoding detection, since [UTF-8, UTF-16 and UTF-32 are all supported](http://tools.ietf.org/html/rfc4627#section-3)).
### Dropping Python 2.5

This brings up the question of Python 2.5 support. In **setup.py**, it is clear that pingdom-python depends on requests 0.10.8 or newer. As a side note, everything seems to be working okay with requests 2.1.0.

``` python
      install_requires=[ 'requests>=0.10.8', 'simplejson'],
```

However, in requests 0.10.1, support for Python 2.5 [was dropped](http://requests.readthedocs.org/en/latest/community/updates/#id38). Unless Python 2.5 is a requirement, I would recommend dropping Python 2.5 support completely (as this pull request does). This means we can drop the simplejson dependency since Python 2.6 and newer have JSON support built-in.

---

:smile: Hi Mike.
