### PR TITLE
Make pingdom-pythong installable with setuptools >= 57.5.0

### DIFF
--- a/pingdom/connection.py
+++ b/pingdom/connection.py
@@ -77,7 +77,7 @@ class PingdomRequest(object):
             log.debug(msg)
             response = getattr(requests, self.method)(url=self.url,
                 data=self.post_data, auth=self.auth, headers=self.headers)
-        except requests.exceptions.RequestException, e:
+        except requests.exceptions.RequestException as e:
             raise PingdomError(e)
         return PingdomResponse(response)
 
@@ -156,7 +156,7 @@ class PingdomConnection(object):
 
         try:
             resp = PingdomRequest(self, 'checks', post_data=post_data).fetch()
-        except PingdomError, e:
+        except PingdomError as e:
             logging.error(e)
         else:
             return PingdomCheck(resp.content['check'])
@@ -171,7 +171,7 @@ class PingdomConnection(object):
             rs = 'checks/%s' % check_id
             response = PingdomRequest(self, rs, post_data=post_data,
                 method='PUT').fetch()
-        except PingdomError, e:
+        except PingdomError as e:
             logging.error(e)
         else:
             return response.content['message']

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ import sys
 from setuptools import setup
 
 setup(name='pingdom',
-      version="0.2.1",
+      version="0.2.2",
       description='Pingdom Library',
       long_description="""3rd-party Python interface to Pingdom's REST API.""",
       author='Mike Babineau',
       author_email='michael.babineau@gmail.com',
-      install_requires=[ 'requests>=0.10.8' ],
+      install_requires=[ 'requests>=0.10.8', 'setuptools>=57.5.0' ],
       url='https://github.com/mbabineau/pingdom-python',
       packages=['pingdom'],
       license='Apache v2.0',

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,6 @@
 import sys
 from setuptools import setup
 
-extra = {}
-if sys.version_info >= (3,):
-    extra['use_2to3'] = True
-
 setup(name='pingdom',
       version="0.2.1",
       description='Pingdom Library',
@@ -23,5 +19,4 @@ setup(name='pingdom',
                    'License :: OSI Approved :: Apache Software License',
                    'Operating System :: OS Independent',
                    'Topic :: System :: Monitoring', ],
-      **extra
       )


### PR DESCRIPTION
Add patch to fix install issue with setuptools.
Based on the work from @ksmadsen https://github.com/mbabineau/pingdom-python/compare/master...Jobindex:pingdom-python:master
